### PR TITLE
release 0.5

### DIFF
--- a/device_namer/README.MD
+++ b/device_namer/README.MD
@@ -1,0 +1,48 @@
+# Meraki Device Namer
+
+### Purpose:
+This function performs the role of creating names for devices when a site is created.
+
+### Dependencies:
+
+<br />
+
+##### <b> Application functions </b>
+
+```site_creator()```
+
+```meraki_importer()```
+
+##### <b> Data </b>
+
+```(serials,site_name)```
+
+#### <b> Overview: </b>
+
+Obtains variable data from application. The serials data is a list, and the site_name is a string variable which includes the whole name which the device name will be appended to.
+
+The class will make two API calls. The first API call is a <i>get</i> api call which uses the serial number and then gets back json data. Currently the code has loops that match a criteria based on a particular key and value in the json returned data. Specifically the code is looking for what 'model' is returned. If the model matches, then the loop begins and it iterates over all respective serials.
+
+The loop will create a device name and number depending on the model and number of devices matching that loop. It will do an api call <i>update</i> to the Meraki dashboard matching the respective serial number and update it with it's respective name.
+
+Once this work is done it will then break out to the application to continue next steps.
+
+#### Device Groups:
+
+> Switches = SW
+
+> Access Points = AP
+
+> Security Appliances = MX 
+
+#### Examples:
+
+##### Meraki MX Device
+
+> FF-AU-SITE3-MX1
+
+##### 2x Meraki Switches
+
+> FF-AU-SITE3-SW1
+> FF-AU-SER3-SW2
+

--- a/device_namer/device.py
+++ b/device_namer/device.py
@@ -1,0 +1,53 @@
+import meraki, os
+
+class deviceNamer:
+    def __init__(self,site_name,serials):
+        self.serials = serials
+        self.site = site_name
+        self.api = os.environ.get('meraki_api_key')
+        self.dashboard = meraki.DashboardAPI(self.api)
+        self_orgid = ""
+
+    def update(self,name,serial,number):
+        updated = False
+        while updated == False:
+            try:
+                number = str(number)
+                update_device = self.dashboard.devices.updateDevice(serial=(serial), name=(name + number))
+                if self.serials == []:
+                    print('Naming Complete')
+                    updated = True
+                    return updated, name
+                else:
+                    break
+            except ValueError:
+                break
+
+    def name(self):
+        complete = False
+        #print(serials)
+        ap = []
+        sw = []
+        mx = []
+        while complete == False:
+            for serial in (self.serials):
+                get_device = self.dashboard.devices.getDevice(serial=(serial))
+                get_type = get_device['model']
+                if get_type in ('MR36'):
+                    ap.append(serial)
+                    for number, serial in enumerate(ap, start=1):
+                        name = (self.site + '-AP')
+                        self.update(name,serial,number)
+                elif get_type in ('MS120-24P'):
+                    sw.append(serial)
+                    for number, serial in enumerate(sw, start=1):
+                        name = (self.site + '-SW')
+                        self.update(name,serial,number)
+                elif get_type in ('MX67C-WW'):
+                    mx.append(serial)
+                    print(mx)
+                    for number, serial in enumerate(mx, start=1):
+                        name = (self.site + '-MX')
+                        self.update(name,serial,number)
+                
+            complete = True

--- a/menu/menu.py
+++ b/menu/menu.py
@@ -4,6 +4,7 @@ from menu.text import BRAND, COUNTRY, CREATE_SITE_TEXT, TOP_SELECT_TEXT, SITE_NA
 from meraki_importer.importer import importer
 import site_creator.brander, site_creator.namer, site_creator.network
 from menu.clear import clear
+from device_namer import device
 
 # Temp test text
 temp_text1 = 'You have made a selection thats not ready yet'
@@ -62,6 +63,8 @@ def text_menu():
                         if confirm == 1:
                             create_site = site_creator.network.orgNetwork(site_name,serials)
                             create_site.create()
+                            device_name = device.deviceNamer(site_name,serials)
+                            device_name.get()
                             complete = True
                             clear()
                             print(COMPLETE)
@@ -86,6 +89,8 @@ def text_menu():
                         if confirm == 1:
                             create_site = site_creator.network.orgNetwork(site_name, serials)
                             create_site.create()
+                            device_name = device.deviceNamer(site_name,serials)
+                            device_name.get()
                             complete = True
                             clear()
                             print(COMPLETE)
@@ -110,6 +115,8 @@ def text_menu():
                         if confirm == 1:
                             create_site = site_creator.network.orgNetwork(site_name, serials)
                             create_site.create()
+                            device_name = device.deviceNamer(site_name,serials)
+                            device_name.get()
                             clear()
                             print(COMPLETE)
                             complete = True


### PR DESCRIPTION
Added device_namer feature

This feature allows the application to name devices added to the site. It will also number them consecutively based on the order of the serials. 

In this release the device_namer is still limited in capabilities and requires manual updating of model name in the code. In future release this will reference a another list or dictionary to verify if the model is part of the AP, SW or MX device families.